### PR TITLE
Fixes /fill and /clone commands to work in extended-height worlds (e.g. Cubic Chunks and similar).

### DIFF
--- a/src/main/java/com/vova7865/commandomatic/commands/CommandExtendedClone.java
+++ b/src/main/java/com/vova7865/commandomatic/commands/CommandExtendedClone.java
@@ -81,11 +81,9 @@ public class CommandExtendedClone extends CommandBase
                     {
                         flag = true;
                     }
-
-                    if (structureboundingbox.minY >= 0 && structureboundingbox.maxY < 256 && structureboundingbox1.minY >= 0 && structureboundingbox1.maxY < 256)
+                    World world = sender.getEntityWorld();
+                    if ((!world.isOutsideBuildHeight(blockpos)) && (!world.isOutsideBuildHeight(blockpos1)) && (!world.isOutsideBuildHeight(blockpos2)) && (!world.isOutsideBuildHeight(blockpos2.add(structureboundingbox.getLength()))))
                     {
-                        World world = sender.getEntityWorld();
-
                         if (world.isAreaLoaded(structureboundingbox) && world.isAreaLoaded(structureboundingbox1))
                         {
                             boolean flag1 = false;

--- a/src/main/java/com/vova7865/commandomatic/commands/CommandExtendedFill.java
+++ b/src/main/java/com/vova7865/commandomatic/commands/CommandExtendedFill.java
@@ -83,10 +83,9 @@ public class CommandExtendedFill extends CommandBase implements ICommand
 //            {
 //                throw new CommandException("commands.fill.tooManyBlocks", new Object[] {i, Integer.valueOf(32768)});
 //            }
-             if (blockpos2.getY() >= 0 && blockpos3.getY() < 256)
+            World world = sender.getEntityWorld();
+            if ((!world.isOutsideBuildHeight(blockpos2)) && (!world.isOutsideBuildHeight(blockpos3)))
             {
-                World world = sender.getEntityWorld();
-
                 for (int j = blockpos2.getZ(); j <= blockpos3.getZ(); j += 16)
                 {
                     for (int k = blockpos2.getX(); k <= blockpos3.getX(); k += 16)


### PR DESCRIPTION
Uses world.isOutsideBuildHeight() instead of hardcoded fixed values to allow /fill and /clone commands to work outside of vanilla build range in extended-height worlds, such as those created using the Cubic Chunks worlds, while still properly limiting their coordinate range in vanilla worlds.

Mainly wrote these changes because a user created an issue at https://github.com/OpenCubicChunks/CubicChunks/issues/533 rather than in the Command-O-Matic GitHub issues where it belonged, but I figured that it was worth fixing anyways.